### PR TITLE
[MTS/LT][93579030] Fix data extension row delete

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,9 +21,12 @@ GEM
       gyoku (>= 0.4.0)
       nokogiri
     builder (3.2.2)
+    byebug (4.0.5)
+      columnize (= 0.9.0)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
+    columnize (0.9.0)
     coveralls (0.8.0)
       multi_json (~> 1.10)
       rest-client (>= 1.6.8, < 2)
@@ -89,6 +92,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.1.0)
+      byebug (~> 4.0)
+      pry (~> 0.10)
     rack (1.6.0)
     rake (10.4.2)
     rb-fsevent (0.9.4)
@@ -161,6 +167,7 @@ DEPENDENCIES
   guard-rspec
   its
   pry
+  pry-byebug
   rake
   rspec
   webmock

--- a/fuelsdk.gemspec
+++ b/fuelsdk.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "its"
   spec.add_development_dependency "webmock"

--- a/lib/fuelsdk/objects.rb
+++ b/lib/fuelsdk/objects.rb
@@ -215,10 +215,7 @@ module FuelSDK
 
       private
         def add_customer_key data
-          data.each do |d|
-            next if d.include? 'CustomerKey'
-            d['CustomerKey'] = customer_key
-          end
+          data['CustomerKey'] ||= customer_key
         end
 
         def retrieve_required
@@ -325,7 +322,7 @@ module FuelSDK
     end
 
     def get
-        super id
+      super id
     end
 
     class << self
@@ -384,26 +381,25 @@ module FuelSDK
   end
 
   class Patch < Objects::Base
-      include Objects::Soap::CUD
-      attr_accessor :id
+    include Objects::Soap::CUD
+    attr_accessor :id
 
-      def initialize client, id, properties
-        self.properties = properties
-        self.client = client
-        self.id = id
-      end
+    def initialize client, id, properties
+      self.properties = properties
+      self.client = client
+      self.id = id
+    end
 
-      def patch
-        super
-      end
+    def patch
+      super
+    end
 
-      class << self
-        def new client, id, properties=nil
-          o = self.allocate
-          o.send :initialize, client, id, properties
-          return o.patch
-        end
+    class << self
+      def new client, id, properties=nil
+        o = self.allocate
+        o.send :initialize, client, id, properties
+        return o.patch
       end
+    end
   end
-
 end

--- a/lib/fuelsdk/soap.rb
+++ b/lib/fuelsdk/soap.rb
@@ -337,7 +337,7 @@ module FuelSDK
       }
     end
 
-    def format_dataextension_cud_properties properties
+    def format_dataextension_cud_properties properties, action
       Array.wrap(properties).each do |p|
         formated_attrs = []
         p.each do |k, v|
@@ -348,8 +348,13 @@ module FuelSDK
           end
         end
         unless formated_attrs.blank?
-          p['Properties'] ||= {}
-          (p['Properties']['Property'] ||= []).concat formated_attrs
+          if action == :delete
+            p['Keys'] ||= {}
+            (p['Keys']['Key'] ||= []).concat formated_attrs
+          else
+            p['Properties'] ||= {}
+            (p['Properties']['Property'] ||= []).concat formated_attrs
+          end
         end
       end
     end
@@ -373,12 +378,12 @@ module FuelSDK
       end
     end
 
-    def normalize_properties_for_cud object_type, properties
+    def normalize_properties_for_cud object_type, properties, action
       properties = Array.wrap(properties)
       raise 'Object properties must be a Hash' unless properties.first.kind_of? Hash
 
       if is_a_dataextension? object_type
-        format_dataextension_cud_properties properties
+        format_dataextension_cud_properties properties, action
       else
         format_object_cud_properties object_type, properties
       end
@@ -388,7 +393,7 @@ module FuelSDK
     private
 
       def soap_cud action, object_type, properties
-        properties = normalize_properties_for_cud object_type, properties
+        properties = normalize_properties_for_cud object_type, properties, action
         message = create_objects_message object_type, properties
         soap_request action, message
       end

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -412,14 +412,13 @@ describe FuelSDK::DataExtension::Row do
     }
 
     it 'raises an error when missing both name and customer key' do
-      subject.properties = [{'Name' => 'Some DE'}, {'Name' => 'Some DE'}]
+      subject.properties = {'Name' => 'Some DE'}
       expect{subject.post}.to raise_error('Unable to process DataExtension::Row ' \
         'request due to missing CustomerKey and Name')
     end
 
     it 'uses explicitly defined properties' do
-      subject.properties = [{'CustomerKey' => 'Subscribers',
-        'Properties' => {'Property' => [{'Name' => 'Name', 'Value' => 'Justin'}]}}]
+      subject.properties = {'Name' => 'Name', 'Value' => 'Justin'}
       expect(subject.post).to eq([
         'DataExtensionObject', [{
           'CustomerKey' => 'Subscribers',
@@ -429,8 +428,7 @@ describe FuelSDK::DataExtension::Row do
 
     it 'inserts customer key into properties when set using accessor' do
       subject.customer_key = 'Subscribers'
-      subject.properties = [{'Properties' => {
-        'Property' => [{'Name' => 'Name', 'Value' => 'Justin'}]}}]
+      subject.properties = {'Name' => 'Name', 'Value' => 'Justin'}
       expect(subject.post).to eq([
         'DataExtensionObject', [{
           'CustomerKey' => 'Subscribers',
@@ -446,8 +444,7 @@ describe FuelSDK::DataExtension::Row do
       rsp.stub(:success?).and_return true
 
       subject.stub_chain(:client, :soap_get).and_return(rsp)
-      subject.properties = [{'Properties' => {
-        'Property' => [{'Name' => 'Name', 'Value' => 'Justin'}]}}]
+      subject.properties = {'Name' => 'Name', 'Value' => 'Justin'}
 
       expect(subject.post).to eq([
         'DataExtensionObject', [{
@@ -458,7 +455,7 @@ describe FuelSDK::DataExtension::Row do
 
     it 'correctly formats array property' do
       subject.customer_key = 'Subscribers'
-      subject.properties = [{'Name' => 'Justin'}]
+      subject.properties = {'Name' => 'Justin'}
 
       expect(subject.post).to eq(
         ["DataExtensionObject", [{"Name"=>"Justin", "CustomerKey"=>"Subscribers"}]]

--- a/spec/soap/cud_spec.rb
+++ b/spec/soap/cud_spec.rb
@@ -66,7 +66,8 @@ describe FuelSDK::Soap do
 
       expect(client.normalize_properties_for_cud(
         'Subscriber',
-        [{'Email' => 'dev@exacttarget.com', 'FirstName' => 'Devy'}]
+        [{'Email' => 'dev@exacttarget.com', 'FirstName' => 'Devy'}],
+        :create
       )).to eq(
           [{
             'Email' => 'dev@exacttarget.com',
@@ -82,7 +83,8 @@ describe FuelSDK::Soap do
 
       expect(client.normalize_properties_for_cud(
         'Subscriber',
-        {'Email' => 'dev@exacttarget.com', 'FirstName' => 'Devy'}
+        {'Email' => 'dev@exacttarget.com', 'FirstName' => 'Devy'},
+        :create
       )).to eq(
           [{
             'Email' => 'dev@exacttarget.com',

--- a/spec/soap/dataextension_spec.rb
+++ b/spec/soap/dataextension_spec.rb
@@ -1,22 +1,15 @@
 require 'spec_helper'
 
 describe FuelSDK::Soap do
-
   let(:client) { FuelSDK::Client.new }
 
-  subject { client }
-
   describe '#format_cud_properties_for_dataextension' do
-    let(:de_properties) {
-      [{'CustomerKey' => 'Orders', 'total' => 1}]
-    }
     it 'leaves CustomerKey alone an puts other attributes in name value pairs under Properies' do
-      expect(client.format_dataextension_cud_properties de_properties).to eq([{
+      properties = [{'CustomerKey' => 'Orders', 'total' => 1}]
+      expect(client.format_dataextension_cud_properties(properties, :create)).to eq([{
         'CustomerKey' => 'Orders',
          'Properties' => {'Property' => [{'Name' => 'total', 'Value' => 1}]}
        }])
     end
   end
-
 end
-


### PR DESCRIPTION
The ExactTarget API specifies the use of "Key" and "Keys" elements
instead of "Property" and "Properties" when deleting a data extension
row. We now pass the action into the method that constructs the relevant
part of the SOAP request. That method decides what elements to use,
depending on what action is being performed. In the future, it may be
good to create some specialized objects to handle variations in
behavior.

`#add_customer_key` now assumes that the properties attribute is a hash.
When performing post, patch, or delete requests, the official
documentation uses a hash for the properties attribute. The old
implementation of the method assumed that the properties attribute was
an array.

Three tests fail. However, I am assuming the ExactTarget API changed at
one point. I am not sure what the desired output of the tested methods
is supposed to be now.